### PR TITLE
Update README with maintenance warning and alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DeepL TUI
 
 > [!WARNING]
-> This project is no longer maintained. Use the [deepl-cli](https://github.com/DeepLcom/deepl-cli) instead.
+> Maintenance of this project has moved back to its original author at [codeberg.org/and2345/deepl-tui](https://codeberg.org/and2345/deepl-tui).
 
 `deepl-tui` is a terminal user interface for the DeepL language translation API.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # DeepL TUI
 
+> [!WARNING]
+> This project is no longer maintained. Use the [deepl-cli](https://github.com/DeepLcom/deepl-cli) instead.
+
 `deepl-tui` is a terminal user interface for the DeepL language translation API.
 
 ![](./assets/demo/demo.gif)


### PR DESCRIPTION
with the release of the new [deepl-CLI](https://github.com/DeepLcom/deepl-cli), we should direct users to that instead. Once this PR goes in, I also would like to mark this repo as archived/read-only in the GH settings